### PR TITLE
Modified prediction endpoint to return two distinct predictions

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,1 @@
+MODEL_TO_USE = "gaussian"

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ def read_root():
 
 @app.get("/get_prediction")
 def get_prediction(feature_a: float, feature_b: float):
-    return {"prediction": gauss(mu=feature_a, sigma=feature_b)}
+    return {"predictions":[gauss(mu=feature_a, sigma=feature_b), gauss(mu=feature_a, sigma=feature_b) ]}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What (globally what are the changes for)

This PR is about enabling the `get_prediction` endpoint to return a list of predictions instead of a single one.

## Why

The front-end team would like to display two different values of prediction. User will click on the one s.he prefers.

## Changes

- In `app/main.py`, I added a list of predictions as output of the `get_prediction`endpoint
- In `config.py` I tweaked the default of `MODEL_TO_USE`

## Tests
- We did nothing (sorry)